### PR TITLE
Growth rates

### DIFF
--- a/src/main_ms.py
+++ b/src/main_ms.py
@@ -156,7 +156,7 @@ def main(data_path,step_length,param_path,solver=None):
     # param_path = '../data/scenarios/' #for testing
     # data_path = '../data/utopia.txt' #for testing
     # step_length = [1,5] #for testing
-    solver=None #for testing
+    #solver=None #for testing
     if type(step_length)==int:
         dic_yr_in_steps, full_steps = ds.split_dp(data_path,step_length)
         all_steps = len(dic_yr_in_steps)

--- a/src/new_scen.py
+++ b/src/new_scen.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import os
 import ts_gen as tg
-import main_ms as mm #for testing
+#import main_ms as mm #for testing
 #%% Main function to coordinate the script
 def main(path_data,step,dic_dec,dic_scen_dec,dic_yrs):
     # path_data = '../data/step2/C0E0/C0' #for testing

--- a/src/ts_gen.py
+++ b/src/ts_gen.py
@@ -2,7 +2,7 @@
 #%% Import of required packages
 import pandas as pd
 import sys
-import main_ms as mm #for testing
+#import main_ms as mm #for testing
 #%% Main function
 "The main function receives the dataframe with the parameter information that should go into a datapackage..."
 def main(df,dic_yrs,path_data,step,dp):
@@ -22,7 +22,6 @@ def main(df,dic_yrs,path_data,step,dp):
         path_data_ps = '../data/step%(step)s/%(scens)s/datapackage%(dp_p)s/data' % {'step': step, 'scens': scens, 'dp_p': dp-1}
     last_yr_ps = dic_yrs[dp]['VALUE'].min()-1
     df_w = df[df['YEAR'].isnull()]
-    print(df_w)
     col = list(df_w.columns)
     df_out = pd.DataFrame(columns=col)
     for p in df_w['PARAMETER'].unique():


### PR DESCRIPTION
The additions in this PR address #15 . It is now possible to indicate a growth rate in a decision file in the scenario folder, under the condition that the affected parameter has been defined in the step(s) before. The script will then use the last value of the parameter from the previous step and the growth rate to generate a new time-series for the next step.