### PR TITLE
Correct set alignment 

### DIFF
--- a/src/osemosys_step/main_utils.py
+++ b/src/osemosys_step/main_utils.py
@@ -504,15 +504,20 @@ def apply_option_data(original: pd.DataFrame, option: pd.DataFrame) -> pd.DataFr
         pd.DataFrame
             dataframe with option values applied
     """
-    if not (original.columns.to_list()) == (option.columns.to_list()):
+    expected_columns = original.columns.tolist()
+    available_columns = [x for x in option if x in expected_columns]
+    if not all(x in expected_columns for x in available_columns):
         logger.error(f"columns for original are {original.columns} and columns to apply are {option.columns}")
         logger.error("Exiting...")
         sys.exit()
     option = option[list(original)] # align column headers
-    df = pd.concat([original, option])
-    subset = list(df)
-    subset.remove("VALUE") # For dropping duplicates
-    df = df.drop_duplicates(keep="last", subset=subset).reset_index(drop=True)
+    if original.empty:
+        df = option
+    else:
+        df = pd.concat([original, option])
+    sets = list(df)
+    sets.remove("VALUE") # For dropping duplicates
+    df = df.drop_duplicates(keep="last", subset=sets).reset_index(drop=True)
     return df
 
 def get_res_cap_next_steps(step: int, n_steps: int, data_path: str, actual_yrs_in_steps: Dict) -> pd.DataFrame:


### PR DESCRIPTION
In this PR I add functionality to define option data over any set. for example, to apply an emission limit and a capacity constraint to the same scenario data, you can define data like so: 

```
PARAMETER,REGION,TECHNOLOGY,EMISSION,OPTION,YEAR,VALUE
TotalAnnualMaxCapacityInvestment,UTOPIA,IMPHCO1,,0,1990,999999999
TotalAnnualMaxCapacityInvestment,UTOPIA,IMPHCO1,,0,1991,999999999
TotalAnnualMaxCapacityInvestment,UTOPIA,IMPHCO1,,0,1992,999999999
...
AnnualEmissionLimit,UTOPIA,,NOX,0,,-50 
AnnualEmissionLimit,UTOPIA,,NOX,1,,-10000
```

While this bypasses the error described in issue #85, I am a little confused on how logic of handling data that is not defined over all sets (ie. `AnnualEmissionLimit` does not have an associated year in the provided example in the issue ticket). @HauHe was this just a mistake? Im not sure where to look to see if `AnnualEmissionLimit` is being applied correctly. I would suggest explicitly defining the year. 