### PR TITLE
Removed Glpk dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ dependencies = [
   "otoole>=1.1",
   "snakemake",
   "click",
-  "tqdm",
-  "glpk"
+  "tqdm"
   ]
 
 [project.urls]

--- a/src/osemosys_step/main.py
+++ b/src/osemosys_step/main.py
@@ -65,6 +65,19 @@ def run(input_data: str, step_length: int, path_param: str, cores: int, solver=N
     """Main entry point for workflow"""
 
     ##########################################################################
+    # Check for needed software
+    ##########################################################################
+
+    # GLPK is needed for the generation of lp file. Hence, it is always needed for running OSeMOSYS_step.
+    try:
+        cmd = f"glpsol --help"
+        subprocess.run(cmd, shell = True)
+    except:
+        logger.error(f"Can't call GLPK. Make sure GLPK is installed on your computer.")
+        print("Can't call GLPK. Make sure GLPK is installed on your computer.")
+        sys.exit()
+
+    ##########################################################################
     # Setup directories
     ##########################################################################
 


### PR DESCRIPTION
To allow for packaging OSeMOSYS_step, this PR removes the dependency on the solver GLPK. It instead introduces a check for an existing GLPK installation, which OSeMOSYS users commonly have on their computer.